### PR TITLE
feat: add static website for Google Play verification

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reality - The Intelligent Life OS</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f9f9f9;
+        }
+        .header {
+            text-align: center;
+            padding: 40px 0;
+        }
+        .logo {
+            width: 180px;
+            border-radius: 20px;
+            margin-bottom: 20px;
+        }
+        h1, h2, h3 {
+            color: #111;
+        }
+        .badges {
+            margin-bottom: 20px;
+        }
+        .badges span {
+            display: inline-block;
+            padding: 5px 10px;
+            margin: 2px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: bold;
+            color: white;
+        }
+        .badge-android { background-color: #3DDC84; }
+        .badge-privacy { background-color: #008080; }
+        .badge-ai { background-color: #800080; }
+        .badge-ads { background-color: #FF0000; }
+        .quote {
+            font-style: italic;
+            font-size: 1.2em;
+            color: #555;
+            text-align: center;
+            margin: 30px 0;
+            border-left: 4px solid #333;
+            padding-left: 20px;
+            display: inline-block;
+        }
+        .quote-container {
+            text-align: center;
+        }
+        .cta-button {
+            display: inline-block;
+            padding: 10px 20px;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+            font-weight: bold;
+            margin-top: 20px;
+        }
+        .cta-button:hover {
+            background-color: #0056b3;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 30px;
+            background-color: white;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 12px;
+            text-align: center;
+        }
+        th {
+            background-color: #f2f2f2;
+        }
+        td:first-child, th:first-child {
+            text-align: left;
+        }
+        .footer-links {
+            text-align: center;
+            margin-top: 50px;
+            padding-top: 20px;
+            border-top: 1px solid #ddd;
+        }
+        .footer-links a {
+            margin: 0 10px;
+            color: #007bff;
+            text-decoration: none;
+        }
+        .footer-links a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+
+    <div class="header">
+        <img src="https://res.cloudinary.com/dnh4fonis/image/upload/v1781091079/ck39669alz53z3vkeiaq.png" alt="Reality Logo" class="logo">
+        <h1>Reality</h1>
+        <h3>The Intelligent Life OS</h3>
+        <p><strong>Developed by Pawan Washudev | Neubofy</strong></p>
+
+        <div class="badges">
+            <span class="badge-android">Platform: Android</span>
+            <span class="badge-privacy">Data: Local + Your G-Drive</span>
+            <span class="badge-ai">AI: Bring Your Own Key</span>
+            <span class="badge-ads">Ads: ZERO</span>
+            <span class="badge-ads">Trackers: ZERO</span>
+        </div>
+
+        <div class="quote-container">
+            <p class="quote">"Stop managing your life. Start commanding it."</p>
+        </div>
+
+        <p><strong>🌟 100% Open Source • Free Forever • No Ads • No Trackers • Any AI (BYO Key)</strong></p>
+
+        <a href="https://github.com/pawanwashudev-official/Reality/releases" class="cta-button" target="_blank">⬇️ Download Latest APK</a>
+    </div>
+
+    <h2>🤔 Why Does Reality Exist?</h2>
+    <p>We searched for the <strong>perfect productivity app</strong>. We found:</p>
+    <ul>
+        <li>❌ <strong>Paid Apps</strong>: Want $50/year just to block Instagram? No thanks.</li>
+        <li>❌ <strong>"Free" Apps</strong>: Selling your data to advertisers. You're the product.</li>
+        <li>❌ <strong>One-Trick Apps</strong>: A timer here. A to-do list there. No integration.</li>
+        <li>❌ <strong>Closed Ecosystems</strong>: Your data locked in proprietary servers.</li>
+    </ul>
+    <p><strong>Reality was born from frustration.</strong> Built by two friends who lost control of their own fingers. Designed for students and working professionals who want to use their phone <strong>for getting things done</strong>, not doom-scrolling.</p>
+
+    <h2>🏆 Reality vs. The Industry</h2>
+    <p>Most apps solve <em>one</em> problem. Reality solves the <strong>entire ecosystem</strong> of productivity.</p>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Feature</th>
+                <th>🌌 Reality (Free & Open)</th>
+                <th>🌳 Forest ($)</th>
+                <th>🛡️ Freedom ($$)</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>Open Source</strong></td>
+                <td>✅ <strong>100%</strong></td>
+                <td>❌</td>
+                <td>❌</td>
+            </tr>
+            <tr>
+                <td><strong>Price</strong></td>
+                <td>✅ <strong>Free Forever</strong></td>
+                <td>Paid Features</td>
+                <td>Subscription</td>
+            </tr>
+            <tr>
+                <td><strong>Ads / Trackers</strong></td>
+                <td>✅ <strong>ZERO</strong></td>
+                <td>Has Ads (Free)</td>
+                <td>❌</td>
+            </tr>
+            <tr>
+                <td><strong>Data Sovereignty</strong></td>
+                <td>✅ <strong>Local + YOUR G-Drive</strong></td>
+                <td>Their Servers</td>
+                <td>Their Servers</td>
+            </tr>
+            <tr>
+                <td><strong>AI Agent</strong></td>
+                <td>✅ <strong>Plans, Sets Alarms, Creates Reports</strong></td>
+                <td>❌</td>
+                <td>❌</td>
+            </tr>
+            <tr>
+                <td><strong>Google Ecosystem Sync</strong></td>
+                <td>✅ <strong>Tasks, Calendar, Docs, Drive</strong></td>
+                <td>❌</td>
+                <td>❌</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h2>💡 The Google Ecosystem Advantage</h2>
+    <p>Reality doesn't reinvent the wheel. It <strong>weaponizes Google's own tools</strong> for your productivity.</p>
+
+    <h3>📄 Google Docs Integration</h3>
+    <ul>
+        <li><strong>AI Diary & Reflection</strong>: Your daily journal is written directly to <strong>Google Docs</strong>.</li>
+        <li><strong>AI Plans</strong>: Tomorrow's plan is a structured document in your Drive.</li>
+    </ul>
+
+    <h3>✅ Google Tasks & Calendar</h3>
+    <ul>
+        <li><strong>Native Sync</strong>: Add a task in Reality → it appears in Google Tasks instantly.</li>
+        <li><strong>Schedule Adherence XP</strong>: Earn XP for attending your planned calendar blocks.</li>
+    </ul>
+
+    <h3>☁️ Google Drive Backup</h3>
+    <ul>
+        <li><strong>Automatic Reports</strong>: Your daily PDF reports are uploaded to <strong>YOUR</strong> Drive folder.</li>
+        <li><strong>Full Control</strong>: Access, share, or delete them anytime. It's your data.</li>
+        <li><strong>No Our Servers</strong>: We have <strong>literally zero servers</strong>. Your data never touches us.</li>
+    </ul>
+
+    <h2>🔐 Privacy Architecture: Zero Trust</h2>
+    <ul>
+        <li><strong>No Servers</strong>: We have zero backend infrastructure. Your data never touches our systems.</li>
+        <li><strong>Local-First</strong>: All blocking logic, XP calculation, and app state runs 100% on-device.</li>
+        <li><strong>Your Cloud, Your Rules</strong>: Backups go to <strong>your personal Google Drive</strong>. We can't access it.</li>
+        <li><strong>Transient Storage</strong>: Detailed analytics live locally for 3 days, then are wiped or synced to your Drive.</li>
+        <li><strong>Open Source Audit</strong>: Every line of code is public. Build the APK yourself if you don't trust us.</li>
+    </ul>
+
+    <div class="footer-links">
+        <a href="/">Home</a>
+        <a href="/privacypolicy">Privacy Policy</a>
+        <a href="/termsofservice">Terms of Service</a>
+        <p style="margin-top: 20px; font-size: 0.9em; color: #777;">&copy; 2024 Neubofy. All rights reserved.</p>
+    </div>
+
+</body>
+</html>

--- a/website/privacypolicy.html
+++ b/website/privacypolicy.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - Reality App</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 40px 20px;
+            background-color: #f9f9f9;
+        }
+        .container {
+            background-color: white;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+        }
+        h1, h2, h3 {
+            color: #111;
+        }
+        h1 {
+            text-align: center;
+            border-bottom: 2px solid #eee;
+            padding-bottom: 20px;
+            margin-bottom: 30px;
+        }
+        .nav-back {
+            display: inline-block;
+            margin-bottom: 20px;
+            color: #007bff;
+            text-decoration: none;
+        }
+        .nav-back:hover {
+            text-decoration: underline;
+        }
+        .highlight {
+            background-color: #e8f4f8;
+            padding: 15px;
+            border-left: 4px solid #007bff;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+<body>
+
+    <a href="/" class="nav-back">&larr; Back to Home</a>
+
+    <div class="container">
+        <h1>Privacy Policy for Reality</h1>
+        <p><strong>Effective Date:</strong> June 11, 2024</p>
+
+        <p>At Neubofy, we believe your data is yours. The Reality app was built with a fundamental "Zero Trust" architecture, meaning we do not want your data, we do not store your data, and we have no servers to send your data to.</p>
+
+        <div class="highlight">
+            <h3>The TL;DR</h3>
+            <p><strong>We have no servers. We don't collect your data. Everything stays on your device or in your personal Google Drive. There are no ads, no trackers, and no analytics SDKs sending your behavior to third parties.</strong></p>
+        </div>
+
+        <h2>1. Data Collection & Storage</h2>
+        <p>Reality operates exclusively on your local device. All app state, usage statistics, XP calculations, and blocking logic run 100% on-device.</p>
+        <ul>
+            <li><strong>Local-First:</strong> Data required for the app to function is stored locally on your device in secure app storage.</li>
+            <li><strong>No Backend Servers:</strong> Neubofy does not operate any backend databases or APIs to collect user data. Your information never touches our systems.</li>
+            <li><strong>Transient Storage:</strong> Detailed analytical data (like screen time statistics) lives locally for a maximum of 3 days before being wiped or synced exclusively to your personal Google Drive (if enabled).</li>
+        </ul>
+
+        <h2>2. Google Account Integration</h2>
+        <p>Reality offers powerful integration with Google Workspace (Docs, Tasks, Calendar, Drive). To enable these features, you must manually authorize the app via OAuth (Bring Your Own Key).</p>
+        <ul>
+            <li><strong>Your Cloud, Your Rules:</strong> If you enable Google Drive backup or Google Docs integration, your data (daily reports, AI plans, journals) is uploaded directly to <strong>your personal Google Drive</strong>. We cannot access, view, or modify these files.</li>
+            <li><strong>Scopes Used:</strong> Reality requests access to your Google Profile (email and name) solely for displaying it within the app's profile page. It may request access to Drive, Tasks, and Calendar strictly to create and manage files/tasks/events on your behalf as part of the app's core functionality.</li>
+        </ul>
+
+        <h2>3. Third-Party AI Services</h2>
+        <p>Reality uses a "Bring Your Own Key" (BYOK) model for AI features.</p>
+        <ul>
+            <li>When you use the AI Agent (for planning, reflections, etc.), prompts and relevant local context are sent directly from your device to the API provider you configure (e.g., OpenAI, Gemini, Groq, Claude, OpenRouter).</li>
+            <li>We do not proxy these requests. The privacy of your data during AI processing is governed by the respective AI provider you choose.</li>
+        </ul>
+
+        <h2>4. Advertising and Tracking</h2>
+        <p>Reality contains <strong>zero advertisements</strong> and <strong>zero third-party tracking SDKs</strong>. We do not sell, rent, or share your data with advertisers or data brokers.</p>
+
+        <h2>5. Open Source Transparency</h2>
+        <p>Reality is 100% open-source. Every line of code is publicly available on GitHub for audit. You can compile the application yourself to ensure no hidden data collection mechanisms exist.</p>
+
+        <h2>6. Changes to this Policy</h2>
+        <p>If we update this privacy policy, the changes will be reflected on this page. Because we do not collect your email address, you must review this page periodically for updates.</p>
+
+        <h2>7. Contact Us</h2>
+        <p>If you have any questions about this Privacy Policy, please contact us at: <strong>founder@neubofy.in</strong></p>
+    </div>
+
+</body>
+</html>

--- a/website/termsofservice.html
+++ b/website/termsofservice.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service - Reality App</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 40px 20px;
+            background-color: #f9f9f9;
+        }
+        .container {
+            background-color: white;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+        }
+        h1, h2, h3 {
+            color: #111;
+        }
+        h1 {
+            text-align: center;
+            border-bottom: 2px solid #eee;
+            padding-bottom: 20px;
+            margin-bottom: 30px;
+        }
+        .nav-back {
+            display: inline-block;
+            margin-bottom: 20px;
+            color: #007bff;
+            text-decoration: none;
+        }
+        .nav-back:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+
+    <a href="/" class="nav-back">&larr; Back to Home</a>
+
+    <div class="container">
+        <h1>Terms of Service</h1>
+        <p><strong>Effective Date:</strong> June 11, 2024</p>
+
+        <h2>1. Acceptance of Terms</h2>
+        <p>By downloading, accessing, or using the Reality application ("the App"), you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use the App.</p>
+
+        <h2>2. Open Source License</h2>
+        <p>Reality is open-source software licensed under the Apache License 2.0. You may use, reproduce, and distribute the software subject to the terms of the Apache License 2.0. The source code is available publicly on GitHub.</p>
+
+        <h2>3. Description of Service</h2>
+        <p>Reality is a productivity and lifestyle operating system designed to help users manage their time, restrict access to distracting apps, and integrate with Google Workspace and third-party AI services via a "Bring Your Own Key" (BYOK) model. The App operates entirely on your local device.</p>
+
+        <h2>4. User Responsibilities</h2>
+        <ul>
+            <li><strong>Device Admin Permissions:</strong> The App utilizes features such as "Armored Strict Mode" which may request Device Administrator privileges to prevent the App from being uninstalled during active focus sessions. You are solely responsible for enabling this feature and understanding its implications.</li>
+            <li><strong>Third-Party Accounts:</strong> The App allows you to integrate with your personal Google account (Google Drive, Docs, Tasks, Calendar) and third-party AI providers (via API keys). You are responsible for maintaining the security of these accounts and any API keys you provide to the App.</li>
+            <li><strong>Data Loss:</strong> As the App operates locally and saves backups to your personal Google Drive, we are not responsible for any data loss resulting from device failure, accidental deletion, or misconfiguration.</li>
+        </ul>
+
+        <h2>5. Privacy</h2>
+        <p>Your privacy is critically important to us. Please review our <a href="/privacypolicy">Privacy Policy</a> to understand how your local data is handled. We do not collect, store, or transmit your data to our servers.</p>
+
+        <h2>6. Disclaimers</h2>
+        <p>The App is provided on an "AS IS" and "AS AVAILABLE" basis, without warranties of any kind, either express or implied. We do not guarantee that the App will be uninterrupted, error-free, or completely secure.</p>
+        <p>We are not responsible for the actions or content of third-party services (such as Google or AI API providers) that you choose to integrate with the App.</p>
+
+        <h2>7. Limitation of Liability</h2>
+        <p>To the fullest extent permitted by applicable law, Neubofy and its developers shall not be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits or revenues, whether incurred directly or indirectly, or any loss of data, use, goodwill, or other intangible losses, resulting from your access to or use of or inability to access or use the App.</p>
+
+        <h2>8. Changes to Terms</h2>
+        <p>We reserve the right to modify these Terms at any time. We will provide notice of significant changes by updating the "Effective Date" at the top of these Terms. Your continued use of the App after any such changes constitutes your acceptance of the new Terms.</p>
+
+        <h2>9. Contact Information</h2>
+        <p>If you have any questions about these Terms, please contact us at: <strong>founder@neubofy.in</strong></p>
+    </div>
+
+</body>
+</html>

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
- Added `website` directory with index, privacy policy, and terms of service pages.
- Content structured based on app README and "Zero Trust" architecture.
- Added `vercel.json` for auto-clean URLs dropping `.html` extension.
- Changes are isolated and will not affect existing GitHub Actions APK builds.