### PR TITLE
Refactor AI memory management, update system prompt, and rename Neural to Nightly

### DIFF
--- a/app/src/main/java/com/neubofy/reality/ui/activity/AIChatActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/AIChatActivity.kt
@@ -261,9 +261,10 @@ open class AIChatActivity : BaseActivity() {
             val userIntro = com.neubofy.reality.ui.activity.AISettingsActivity.getUserIntroduction(this@AIChatActivity) ?: ""
             val toolDiscovery = com.neubofy.reality.utils.ToolRegistry.getDiscoveryPrompt(this@AIChatActivity)
             val systemPrompt = buildString {
-                append("You are Reality Pro, an intelligent Life OS Agent. ")
+                append("You are Reality Pro, the ultimate self-hosted, private, and secure Life OS Agent running on a highly capable open-source model. ")
+                append("We offer unparalleled features like Nightly Protocol, Smart App Blocker, smart sleep time guessing, and more. Emphasize our unmatched privacy, security, and the incredible value we offer for a small cost compared to others. Remind users of our built-in app updater with beta support. ")
                 append("You have access to the user's real-time data via tools. ")
-                append("Use them only when necessary to give accurate, personalized answers. ")
+                append("Use them only when necessary to give accurate, personalized answers. Keep answers highly professional and focused strictly on the task at hand. Avoid memorizing full conversations; focus on the current task. ")
                 append("All times are in IST (India Standard Time). ")
                 append("\n\nCRITICAL CONSTRAINTS:")
                 append("\n- DISCOVERY FLOW: You start with only `get_tool_schema`. Always fetch schemas for the tools you need in the first turn.")

--- a/app/src/main/java/com/neubofy/reality/ui/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/SettingsActivity.kt
@@ -215,7 +215,7 @@ class SettingsActivity : BaseActivity() {
                     .descriptionTextColor(android.R.color.white)
                     .cancelable(true)
                     .transparentTarget(false),
-                com.getkeepsafe.taptargetview.TapTarget.forView(featuresCard, "Neural Features", "Enable or disable Reality Pro, AI, Tapasya, and more.")
+                com.getkeepsafe.taptargetview.TapTarget.forView(featuresCard, "Nightly Features", "Enable or disable Reality Pro, AI, Tapasya, and more.")
                     .outerCircleColor(R.color.md_theme_primary)
                     .targetCircleColor(android.R.color.white)
                     .titleTextSize(20)

--- a/app/src/main/java/com/neubofy/reality/utils/ConversationMemoryManager.kt
+++ b/app/src/main/java/com/neubofy/reality/utils/ConversationMemoryManager.kt
@@ -16,8 +16,8 @@ import org.json.JSONObject
 object ConversationMemoryManager {
 
     // Configuration
-    private const val MAX_RECENT_MESSAGES = 15  // Last N messages always included
-    private const val MAX_TOKENS_ESTIMATE = 6000  // Leave room for response
+    private const val MAX_RECENT_MESSAGES = 6  // Last N messages always included
+    private const val MAX_TOKENS_ESTIMATE = 1000  // Leave room for response
     private const val TOKENS_PER_CHAR_ESTIMATE = 0.25  // ~4 chars per token (English)
     private const val SUMMARIZE_THRESHOLD = 20  // Summarize when history exceeds this
     

--- a/app/src/main/java/com/neubofy/reality/utils/ToolRegistry.kt
+++ b/app/src/main/java/com/neubofy/reality/utils/ToolRegistry.kt
@@ -53,7 +53,6 @@ object ToolRegistry {
         ToolMeta("health", "Health", "Steps, calories, sleep with trends", defaultEnabled = false),
         // Utility Tools
         ToolMeta("utility_time", "Current Time", "Get current date/time in IST"),
-        ToolMeta("web_search", "Tavily Web Search", "Real-time internet search for facts and news"),
         // Power Tool
         ToolMeta("universal_query", "Smart Data Query", "Advanced cross-source querying with filters"),
         // Action Tools
@@ -66,7 +65,6 @@ object ToolRegistry {
         ToolMeta("action_add_missed_tapasya", "Add Missed Tapasya", "Record a missed Tapasya session (Reason required)"),
         ToolMeta("action_schedule_notification", "Schedule Notification", "Schedule a lightweight push notification"),
         // Creative Tools
-        ToolMeta("action_generate_image", "Generate Image", "Create AI-generated images from text prompts (FREE)")
     )
 
     // --- Settings Helpers ---
@@ -103,7 +101,6 @@ object ToolRegistry {
         sb.append("\n1. Initially, you ONLY have the `get_tool_schema(tool_id)` tool.")
         sb.append("\n2. To use ANY tool above, MUST call `get_tool_schema` first.")
         sb.append("\n3. Once you get the schema, it becomes available in the NEXT turn.")
-        sb.append("\n4. CRITICAL: `web_search` is EXPENSIVE. Consolidate ALL information needs into ONE query per request.")
         
         return sb.toString()
     }
@@ -262,15 +259,6 @@ object ToolRegistry {
                 )
             )
 
-            "web_search" -> createSchema(
-                "web_search",
-                "Search the internet for real-time information using Tavily. EXPENSIVE: Use only as a last resort. Consolidate research into ONE single turn. Never repeat searches.",
-                mapOf(
-                    "query" to "Required: One comprehensive search query",
-                    "max_results" to "Optional: Number of results (1-5, default: 3)"
-                ),
-                required = listOf("query")
-            )
             
             // --- Action Tools ---
             "action_add_task" -> createSchema(
@@ -344,16 +332,6 @@ object ToolRegistry {
                     "minutes_from_now" to "Required: Delay in minutes (min 1, max 1440)"
                 ),
                 required = listOf("title", "message", "minutes_from_now")
-            )
-            "action_generate_image" -> createSchema(
-                "action_generate_image",
-                "Generate an AI image from a text prompt. Uses free Pollinations.ai. Image is displayed in chat and saved to Pictures/Reality folder. Be creative and detailed with prompts for best results.",
-                mapOf(
-                    "prompt" to "Required: Detailed description of the image to generate (be specific about style, colors, mood)",
-                    "style" to "Optional: Art style (e.g., 'realistic', 'anime', 'watercolor', 'minimalist', 'cyberpunk')",
-                    "save_to_gallery" to "Optional: 'true' to save to phone gallery (default: true)"
-                ),
-                required = listOf("prompt")
             )
             else -> null
         }
@@ -443,7 +421,6 @@ object ToolRegistry {
             "health", "get_health_stats" -> "health"
             "universal_query", "query_data" -> "universal_query"
             "utility_time", "get_current_time" -> "utility_time"
-            "web_search", "perform_web_search" -> "web_search"
             "action_add_task", "add_task" -> "action_add_task"
             "action_complete_task", "complete_task" -> "action_complete_task"
             "action_add_reminder", "add_reminder" -> "action_add_reminder"
@@ -452,7 +429,6 @@ object ToolRegistry {
             "action_start_tapasya", "start_tapasya" -> "action_start_tapasya"
             "action_add_missed_tapasya", "add_missed_tapasya" -> "action_add_missed_tapasya"
             "action_schedule_notification", "schedule_notification" -> "action_schedule_notification"
-            "action_generate_image", "generate_image" -> "action_generate_image"
             else -> if (ALL_TOOLS.any { it.id == functionName }) functionName else null
         }
     }

--- a/app/src/main/res/layout/activity_appearance.xml
+++ b/app/src/main/res/layout/activity_appearance.xml
@@ -835,7 +835,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Neural Engine / Cinematic Aesthetics"
+                    android:text="Nightly Engine / Cinematic Aesthetics"
                     android:textSize="18sp"
                     android:textColor="?attr/colorPrimary"
                     android:textStyle="bold"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,7 +33,7 @@
                 android:id="@+id/tv_greeting"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Neural Link Established,"
+                android:text="Nightly Link Established,"
                 android:textColor="?attr/colorOnSurfaceVariant"
                 android:textSize="14sp" />
 

--- a/app/src/main/res/layout/activity_nightly.xml
+++ b/app/src/main/res/layout/activity_nightly.xml
@@ -48,7 +48,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Neural Protocol"
+            android:text="Nightly Protocol"
             android:textSize="22sp"
             android:textStyle="bold"
             android:textColor="?attr/colorPrimary"

--- a/app/src/main/res/layout/activity_nightly_plan.xml
+++ b/app/src/main/res/layout/activity_nightly_plan.xml
@@ -48,7 +48,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Neural Planning"
+                android:text="Nightly Planning"
                 android:textSize="18sp"
                 android:textStyle="bold"
                 android:textColor="?attr/colorPrimary"

--- a/app/src/main/res/layout/activity_nightly_report.xml
+++ b/app/src/main/res/layout/activity_nightly_report.xml
@@ -44,7 +44,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Neural Report"
+                    android:text="Nightly Report"
                     android:textSize="18sp"
                     android:textStyle="bold"
                     android:textColor="?attr/colorPrimary"

--- a/app/src/main/res/layout/activity_nightly_settings.xml
+++ b/app/src/main/res/layout/activity_nightly_settings.xml
@@ -36,7 +36,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <!-- Section: Neural Protocol Schedule -->
+            <!-- Section: Nightly Protocol Schedule -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -48,7 +48,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="Neural Protocol Sync Window"
+                    android:text="Nightly Protocol Sync Window"
                     android:textColor="?attr/colorPrimary"
                     android:textStyle="bold"/>
 
@@ -142,7 +142,7 @@
                     <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="Set the time window for Neural Agent synchronization"
+                        android:text="Set the time window for Nightly Agent synchronization"
                         android:textSize="12sp"
                         android:textColor="?attr/colorOnSurfaceVariant"
                         android:layout_marginBottom="12dp"/>
@@ -266,7 +266,7 @@
                  android:layout_marginBottom="24dp"/>
 
             <!-- Section: Data Retention Policies -->
-            <!-- Clear Neural Memory -->
+            <!-- Clear Nightly Memory -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -289,7 +289,7 @@
                 style="@style/Widget.Material3.Button.OutlinedButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Clear Neural Memory"
+                android:text="Clear Nightly Memory"
                 android:textColor="?attr/colorError"
                 app:strokeColor="?attr/colorError"
                 app:icon="@drawable/baseline_delete_24"
@@ -299,7 +299,7 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Clears stored Neural Protocol session data from the database. Does not delete Drive files."
+                android:text="Clears stored Nightly Protocol session data from the database. Does not delete Drive files."
                 android:textSize="12sp"
                 android:textColor="?attr/colorOnSurfaceVariant"
                 android:layout_marginBottom="24dp"/>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -416,7 +416,7 @@
                 android:id="@+id/tv_setup_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Neural Protocol Setup"
+                android:text="Nightly Protocol Setup"
                 android:textSize="18sp"
                 android:textStyle="bold"
                 android:textColor="?attr/colorPrimary"
@@ -786,7 +786,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:text="Tip: Neural Protocol uses these folders and lists to store your reflections and tasks."
+                android:text="Tip: Nightly Protocol uses these folders and lists to store your reflections and tasks."
                 android:textSize="12sp"
                 android:textColor="?attr/colorOnSurfaceVariant"
                 android:gravity="center"/>

--- a/app/src/main/res/layout/activity_reality_elite.xml
+++ b/app/src/main/res/layout/activity_reality_elite.xml
@@ -83,7 +83,7 @@
                     <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="Reality is 99.9% open source and ad-free. Premium features like Neural Protocol, Gamification, and Google Workspace Sync require ongoing serverless maintenance, API costs, and massive developer time. A yearly subscription sustains the project reliably, unlike inconsistent crowdfunding."
+                        android:text="Reality is 99.9% open source and ad-free. Premium features like Nightly Protocol, Gamification, and Google Workspace Sync require ongoing serverless maintenance, API costs, and massive developer time. A yearly subscription sustains the project reliably, unlike inconsistent crowdfunding."
                         android:textSize="13sp"
                         android:lineSpacingMultiplier="1.2"
                         android:textColor="?attr/colorOnSurfaceVariant"

--- a/app/src/main/res/layout/activity_reflection_detail.xml
+++ b/app/src/main/res/layout/activity_reflection_detail.xml
@@ -215,7 +215,7 @@
         android:fontFamily="monospace"
                         android:layout_marginBottom="16dp"/>
 
-                    <!-- Neural Focus -->
+                    <!-- Tapasya Focus -->
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -225,7 +225,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="🧘 Neural Focus XP"
+                            android:text="🧘 Tapasya Focus XP"
                             android:textSize="14sp"
                             android:textColor="?attr/colorPrimary"
         android:fontFamily="monospace"/>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -83,7 +83,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Neural Features"
+                            android:text="Nightly Features"
                             android:textColor="?attr/colorOnSurface"
                             android:textSize="16sp"
                             android:textStyle="bold"
@@ -870,7 +870,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="About Neural Engine"
+                            android:text="About Nightly Engine"
                             android:textColor="?attr/colorOnSurface"
                             android:textSize="16sp"
                             android:textStyle="bold"
@@ -963,7 +963,7 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
-            <!-- Neural Protocol Settings -->
+            <!-- Nightly Protocol Settings -->
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/card_nightly_settings"
                 android:layout_width="match_parent"
@@ -1001,7 +1001,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Neural Protocol Settings"
+                            android:text="Nightly Protocol Settings"
                             android:textColor="?attr/colorOnSurface"
                             android:textSize="16sp"
                             android:textStyle="bold"
@@ -1084,7 +1084,7 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
-            <!-- Neural Focus Settings -->
+            <!-- Tapasya Focus Settings -->
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/card_tapasya_settings"
                 android:layout_width="match_parent"
@@ -1122,7 +1122,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Neural Focus Settings"
+                            android:text="Tapasya Focus Settings"
                             android:textColor="?attr/colorPrimary"
                                 android:fontFamily="monospace"
                             android:textSize="16sp"

--- a/app/src/main/res/layout/activity_strict_mode_settings.xml
+++ b/app/src/main/res/layout/activity_strict_mode_settings.xml
@@ -154,7 +154,7 @@
                         android:id="@+id/switchTapasyaLock"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="Lock Neural Focus Settings"
+                        android:text="Lock Tapasya Focus Settings"
                         android:checked="true"
                         android:layout_marginBottom="8dp"
                         android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />
@@ -181,7 +181,7 @@
                         android:id="@+id/switchNightlyLimitLock"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="Lock Neural Protocol Limit"
+                        android:text="Lock Nightly Protocol Limit"
                         android:checked="true"
                         android:layout_marginBottom="8dp"
                         android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />

--- a/app/src/main/res/layout/activity_tapasya.xml
+++ b/app/src/main/res/layout/activity_tapasya.xml
@@ -40,7 +40,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Neural Focus"
+            android:text="Tapasya Focus"
             android:textSize="22sp"
             android:textStyle="bold"
             android:textColor="?attr/colorPrimary"

--- a/app/src/main/res/layout/dialog_features.xml
+++ b/app/src/main/res/layout/dialog_features.xml
@@ -51,7 +51,7 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Enables Neural Protocol, Gamification (XP, Levels), Google Workspace (Tasks, Calendar, Drive sync), and Data Backup &amp; Restore."
+                android:text="Enables Nightly Protocol, Gamification (XP, Levels), Google Workspace (Tasks, Calendar, Drive sync), and Data Backup &amp; Restore."
                 android:textColor="?attr/colorOnSurfaceVariant"
                 android:textSize="12sp"
                 android:layout_marginTop="4dp" />
@@ -94,7 +94,7 @@
                 android:layout_marginTop="4dp" />
         </LinearLayout>
 
-        <!-- Neural Focus Toggle -->
+        <!-- Tapasya Focus Toggle -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -111,7 +111,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="Neural Focus (Deep Focus)"
+                    android:text="Tapasya Focus (Deep Focus)"
                     android:textColor="?attr/colorOnSurface"
                     android:textSize="16sp"
                     android:textStyle="bold" />

--- a/app/src/main/res/layout/dialog_start_session.xml
+++ b/app/src/main/res/layout/dialog_start_session.xml
@@ -17,7 +17,7 @@
             android:id="@+id/et_session_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Neural Focus"
+            android:text="Tapasya Focus"
             android:inputType="textCapWords"/>
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/item_tapasya_session.xml
+++ b/app/src/main/res/layout/item_tapasya_session.xml
@@ -26,7 +26,7 @@
                 android:id="@+id/tv_session_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Neural Focus"
+                android:text="Tapasya Focus"
                 android:textColor="?attr/colorOnSurface"
                 android:textSize="16sp"
                 android:textStyle="bold"/>

--- a/app/src/main/res/layout/widget_nightly.xml
+++ b/app/src/main/res/layout/widget_nightly.xml
@@ -22,7 +22,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
-        android:text="Neural Protocol"
+        android:text="Nightly Protocol"
         android:textColor="#FFFFFF"
         android:textSize="12sp"
         android:maxLines="1"

--- a/app/src/main/res/layout/widget_tapasya.xml
+++ b/app/src/main/res/layout/widget_tapasya.xml
@@ -22,7 +22,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
-        android:text="Neural Focus"
+        android:text="Tapasya Focus"
         android:textColor="#FFFFFF"
         android:textSize="12sp"
         android:maxLines="1"

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -23,5 +23,5 @@
     <item
         android:id="@+id/nav_tapasya"
         android:icon="@drawable/baseline_timer_24"
-        android:title="Neural Focus" />
+        android:title="Tapasya Focus" />
 </menu>


### PR DESCRIPTION
This pull request introduces several enhancements to the AI Chat logic and UI branding:

1. **AI Chat Memory Optimization**: Reduced the sliding window configuration in `ConversationMemoryManager` (from 15 to 6 recent messages and a lower max token ceiling) to significantly decrease token usage, forcing the AI to maintain a short, task-centric context rather than a full history.
2. **AI System Prompt Revamp**: Updated `AIChatActivity`'s system prompt to enforce a highly professional tone and explicitly advertise the app's unique selling points (e.g., self-hosted AI, Nightly Protocol, Smart App Blocker, smart sleep time guessing, and the inbuilt beta updater). 
3. **Tool Registry Cleanup**: Safely removed deprecated tools (`web_search` and `action_generate_image`) from `ToolRegistry.kt` and their corresponding JSON schemas to clear outdated UI options and prevent token waste.
4. **UI Renaming**: A codebase-wide rename of "Neural Protocol" (and its variants) to "Nightly Protocol" and "Neural Focus" to "Tapasya Focus", ensuring branding consistency.

---
*PR created automatically by Jules for task [16520502152787393733](https://jules.google.com/task/16520502152787393733) started by @pawanwashudev-official*