### PR TITLE
Make AI System Prompt Editable & Add Live App Documentation Tools

### DIFF
--- a/app/src/main/java/com/neubofy/reality/ui/activity/AIChatActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/AIChatActivity.kt
@@ -260,15 +260,9 @@ open class AIChatActivity : BaseActivity() {
             // 1. Prepare Initial Context
             val userIntro = com.neubofy.reality.ui.activity.AISettingsActivity.getUserIntroduction(this@AIChatActivity) ?: ""
             val toolDiscovery = com.neubofy.reality.utils.ToolRegistry.getDiscoveryPrompt(this@AIChatActivity)
+            val baseSystemPrompt = com.neubofy.reality.ui.activity.AISettingsActivity.getSystemPrompt(this@AIChatActivity)
             val systemPrompt = buildString {
-                append("You are Reality Elite, an intelligent Life OS Agent, hosted independently using self-hosted, most private and secure AI models to ensure the highest privacy for your users. ")
-                append("You have access to the user's real-time data via tools. ")
-                append("Use them only when necessary to give accurate, personalized answers. Keep answers highly professional and focused strictly on the task at hand. Avoid memorizing full conversations; focus on the current task. ")
-                append("All times are in IST (India Standard Time). ")
-                append("\n\nCRITICAL CONSTRAINTS:")
-                append("\n- DISCOVERY FLOW: You start with only `get_tool_schema`. Always fetch schemas for the tools you need in the first turn.")
-                append("\n- ANTI-LOOP: Do not call the same tool with the same arguments twice.")
-                append("\n- COMPLETION: Your main goal in chats is to complete specific tasks, not to remember the whole conversation. Be concise. \n- PROMOTION: Periodically promote the app features (unmatchable alarm, reminder, Nightly protocol, completely free smart app blocker which is best than other apps, but for very little amount we offer a lot, inbuilt app updater, beta versions, smart sleep time guessing) while emphasizing our self-hosted, private and secure AI usage.")
+                append(baseSystemPrompt)
                 if (userIntro.isNotEmpty()) append("\n\nUser context: $userIntro")
                 append("\n\n$toolDiscovery")
             }

--- a/app/src/main/java/com/neubofy/reality/ui/activity/AISettingsActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/AISettingsActivity.kt
@@ -57,8 +57,33 @@ class AISettingsActivity : BaseActivity() {
             binding.btnEditIntroduction.visibility = android.view.View.GONE
         }
 
-        // Widget Voice Autostart Toggle
         val prefs = com.neubofy.reality.utils.SecurePreferences.get(this, "ai_prefs")
+
+        // System Prompt Setup
+        val savedPrompt = prefs.getString("custom_system_prompt", "")
+        if (savedPrompt.isNullOrEmpty()) {
+            binding.etSystemPrompt.setText(DEFAULT_SYSTEM_PROMPT)
+        } else {
+            binding.etSystemPrompt.setText(savedPrompt)
+        }
+
+        binding.btnSaveSystemPrompt.setOnClickListener {
+            val promptText = binding.etSystemPrompt.text.toString().trim()
+            if (promptText.isEmpty()) {
+                Toast.makeText(this, "System prompt cannot be empty", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            prefs.edit().putString("custom_system_prompt", promptText).apply()
+            Toast.makeText(this, "System prompt saved!", Toast.LENGTH_SHORT).show()
+        }
+
+        binding.btnResetSystemPrompt.setOnClickListener {
+            prefs.edit().remove("custom_system_prompt").apply()
+            binding.etSystemPrompt.setText(DEFAULT_SYSTEM_PROMPT)
+            Toast.makeText(this, "System prompt reset to default", Toast.LENGTH_SHORT).show()
+        }
+
+        // Widget Voice Autostart Toggle
         binding.switchWidgetVoice.isChecked = prefs.getBoolean("widget_voice_autostart", false)
         binding.switchWidgetVoice.setOnCheckedChangeListener { _, isChecked ->
             prefs.edit().putBoolean("widget_voice_autostart", isChecked).apply()
@@ -110,9 +135,16 @@ class AISettingsActivity : BaseActivity() {
     }
 
     companion object {
+        const val DEFAULT_SYSTEM_PROMPT = "You are Reality Elite, an intelligent Life OS Agent, hosted independently using self-hosted, most private and secure AI models to ensure the highest privacy for your users. You have access to the user's real-time data via tools. Use them only when necessary to give accurate, personalized answers. Keep answers highly professional and focused strictly on the task at hand. Avoid memorizing full conversations; focus on the current task. All times are in IST (India Standard Time). \n\nCRITICAL CONSTRAINTS:\n- DISCOVERY FLOW: You start with only `get_tool_schema`. Always fetch schemas for the tools you need in the first turn.\n- ANTI-LOOP: Do not call the same tool with the same arguments twice.\n- COMPLETION: Your main goal in chats is to complete specific tasks, not to remember the whole conversation. Be concise. \n- PROMOTION: Periodically promote the app features (unmatchable alarm, reminder, Nightly protocol, completely free smart app blocker which is best than other apps, but for very little amount we offer a lot, inbuilt app updater, beta versions, smart sleep time guessing) while emphasizing our self-hosted, private and secure AI usage."
+
         fun getUserIntroduction(context: android.content.Context): String? {
             val prefs = com.neubofy.reality.utils.SecurePreferences.get(context, "ai_prefs")
             return prefs.getString("user_introduction", null)
+        }
+
+        fun getSystemPrompt(context: android.content.Context): String {
+            val prefs = com.neubofy.reality.utils.SecurePreferences.get(context, "ai_prefs")
+            return prefs.getString("custom_system_prompt", DEFAULT_SYSTEM_PROMPT) ?: DEFAULT_SYSTEM_PROMPT
         }
     }
 }

--- a/app/src/main/java/com/neubofy/reality/utils/AgentTools.kt
+++ b/app/src/main/java/com/neubofy/reality/utils/AgentTools.kt
@@ -450,6 +450,7 @@ object AgentTools {
                     val newAlarm = com.neubofy.reality.data.model.WakeupAlarm(
                         id = System.currentTimeMillis().toString(),
                         title = title,
+                        description = "",
                         hour = hour,
                         minute = minute,
                         isEnabled = true,

--- a/app/src/main/java/com/neubofy/reality/utils/AgentTools.kt
+++ b/app/src/main/java/com/neubofy/reality/utils/AgentTools.kt
@@ -657,6 +657,38 @@ object AgentTools {
 
 
                 // ==================== UTILITY TOOLS ====================
+                "get_readme_content" -> {
+                    try {
+                        val url = java.net.URL("https://raw.githubusercontent.com/pawanwashudev-official/Reality/main/README.md")
+                        val content = url.readText()
+                        JSONObject().apply {
+                            put("success", true)
+                            put("content", content)
+                        }.toString()
+                    } catch (e: Exception) {
+                        JSONObject().apply {
+                            put("success", false)
+                            put("error", e.message)
+                        }.toString()
+                    }
+                }
+
+                "get_about_content" -> {
+                    try {
+                        val url = java.net.URL(com.neubofy.reality.ui.activity.AboutActivity.ABOUT_MD_URL)
+                        val content = url.readText()
+                        JSONObject().apply {
+                            put("success", true)
+                            put("content", content)
+                        }.toString()
+                    } catch (e: Exception) {
+                        JSONObject().apply {
+                            put("success", false)
+                            put("error", e.message)
+                        }.toString()
+                    }
+                }
+
                 "utility_time", "get_current_time" -> {
                     val format = args.optString("format", "full")
                     val istZone = ZoneId.of("Asia/Kolkata")

--- a/app/src/main/java/com/neubofy/reality/utils/ToolRegistry.kt
+++ b/app/src/main/java/com/neubofy/reality/utils/ToolRegistry.kt
@@ -53,6 +53,8 @@ object ToolRegistry {
         ToolMeta("health", "Health", "Steps, calories, sleep with trends", defaultEnabled = false),
         // Utility Tools
         ToolMeta("utility_time", "Current Time", "Get current date/time in IST"),
+        ToolMeta("get_readme_content", "App README", "Get the content of the app's README.md file"),
+        ToolMeta("get_about_content", "App ABOUT", "Get the content of the app's ABOUT.md file"),
         // Power Tool
         ToolMeta("universal_query", "Smart Data Query", "Advanced cross-source querying with filters"),
         // Action Tools
@@ -259,6 +261,18 @@ object ToolRegistry {
                 )
             )
 
+            "get_readme_content" -> createSchema(
+                "get_readme_content",
+                "Get the full content of the Reality app's README.md file from GitHub. Use this to find general information, features, and setup instructions about the app.",
+                emptyMap()
+            )
+
+            "get_about_content" -> createSchema(
+                "get_about_content",
+                "Get the full content of the Reality app's ABOUT.md file from GitHub. Use this to find detailed information about the app's philosophy, developer, and mission.",
+                emptyMap()
+            )
+
             
             // --- Action Tools ---
             "action_add_task" -> createSchema(
@@ -421,6 +435,8 @@ object ToolRegistry {
             "health", "get_health_stats" -> "health"
             "universal_query", "query_data" -> "universal_query"
             "utility_time", "get_current_time" -> "utility_time"
+            "get_readme_content", "get_readme" -> "get_readme_content"
+            "get_about_content", "get_about" -> "get_about_content"
             "action_add_task", "add_task" -> "action_add_task"
             "action_complete_task", "complete_task" -> "action_complete_task"
             "action_add_reminder", "add_reminder" -> "action_add_reminder"

--- a/app/src/main/res/layout/activity_ai_settings.xml
+++ b/app/src/main/res/layout/activity_ai_settings.xml
@@ -275,7 +275,7 @@
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
-                            android:text="Personalize AI"
+                            android:text="Reality Intelligence Assistant Settings"
                             android:textSize="14sp"
                             android:textColor="?attr/colorPrimary"
         android:fontFamily="monospace"/>
@@ -378,6 +378,61 @@
                             android:textAllCaps="false"
                             app:cornerRadius="8dp"
                             android:layout_marginTop="8dp"/>
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="16dp"
+                            android:hint="System Prompt"
+                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/et_system_prompt"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:inputType="textMultiLine"
+                                android:minLines="5"
+                                android:maxLines="10"
+                                android:gravity="top"/>
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="Modify the AI system prompt to customize how Reality behaves. Warning: advanced users only."
+                            android:textSize="11sp"
+                            android:textColor="?attr/colorOnSurfaceVariant"
+                            android:layout_marginTop="4dp"/>
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:layout_marginTop="8dp"
+                            android:weightSum="2">
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/btn_reset_system_prompt"
+                                style="@style/Widget.Material3.Button.OutlinedButton"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:layout_marginEnd="4dp"
+                                android:text="Reset"
+                                android:textAllCaps="false"
+                                app:cornerRadius="8dp"/>
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/btn_save_system_prompt"
+                                style="@style/Widget.Material3.Button.TonalButton"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:layout_marginStart="4dp"
+                                android:text="Save Prompt"
+                                android:textAllCaps="false"
+                                app:cornerRadius="8dp"/>
+                        </LinearLayout>
                     </LinearLayout>
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
This commit fulfills the user's request to:
1. Rename the personalization section to "Reality Intelligence Assistant Settings".
2. Allow users to edit, save, and reset the AI system prompt.
3. Equip the AI Agent with tools to dynamically fetch and read the live `README.md` and `ABOUT.md` app documentation directly from GitHub.

---
*PR created automatically by Jules for task [4867587685830076598](https://jules.google.com/task/4867587685830076598) started by @pawanwashudev-official*