### PR TITLE
⚡ Refactor Google Tasks fetch to run concurrently

### DIFF
--- a/app/src/main/java/com/neubofy/reality/data/nightly/NightlyPhasePlanning.kt
+++ b/app/src/main/java/com/neubofy/reality/data/nightly/NightlyPhasePlanning.kt
@@ -12,6 +12,9 @@ import com.neubofy.reality.utils.NightlyAIHelper
 import com.neubofy.reality.utils.TerminalLogger
 import com.neubofy.reality.utils.XPManager
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.ZoneId
@@ -801,19 +804,26 @@ class NightlyPhasePlanning(
             val taskLists = tasksManager.getTaskLists(context)
             val allPendingTasks = mutableListOf<JSONObject>()
             
-            for (list in taskLists) {
-                val tasks = tasksManager.getTasks(context, list.id)
-                tasks.forEach { task ->
-                    if (task.status != "completed") {
-                        val json = JSONObject()
-                        json.put("id", task.id)
-                        json.put("list_id", list.id)
-                        json.put("title", task.title)
-                        json.put("due", task.due ?: "null")
-                        json.put("notes", task.notes ?: "")
-                        allPendingTasks.add(json)
+            coroutineScope {
+                val deferredTasks = taskLists.map { list ->
+                    async {
+                        val tasks = tasksManager.getTasks(context, list.id)
+                        val listPending = mutableListOf<JSONObject>()
+                        tasks.forEach { task ->
+                            if (task.status != "completed") {
+                                val json = JSONObject()
+                                json.put("id", task.id)
+                                json.put("list_id", list.id)
+                                json.put("title", task.title)
+                                json.put("due", task.due ?: "null")
+                                json.put("notes", task.notes ?: "")
+                                listPending.add(json)
+                            }
+                        }
+                        listPending
                     }
                 }
+                deferredTasks.awaitAll().forEach { allPendingTasks.addAll(it) }
             }
             
             if (allPendingTasks.isEmpty()) {


### PR DESCRIPTION
💡 **What:** Refactored the `step14_normalizeTasks` method in `NightlyPhasePlanning.kt` to use Kotlin Coroutines (`async` and `awaitAll`) instead of a sequential `for` loop.

🎯 **Why:** Previously, retrieving tasks from multiple Google Tasks lists involved making sequential, synchronous API calls over the network inside a loop. This created an N+1 scaling bottleneck where the total time taken scaled linearly with the number of task lists, potentially causing the Nightly Protocol to hang unnecessarily.

📊 **Measured Improvement:** Exact performance measurements could not be obtained locally because executing this specific code path requires valid, authenticated Google Tasks API credentials (which are not available in the test environment). However, based on standard asynchronous IO practices, executing N independent network requests in parallel via coroutines is mathematically proven to drastically reduce the total duration (from $O(N \times \text{latency})$ to roughly $O(\max(\text{latency}))$) without altering the final combined result. Tests and compilation confirm functional parity.

---
*PR created automatically by Jules for task [14069951541638499476](https://jules.google.com/task/14069951541638499476) started by @pawanwashudev-official*