### PR TITLE
fix: Improve Nightly Protocol state handling and granular reporting for AI steps

### DIFF
--- a/app/src/main/java/com/neubofy/reality/data/nightly/NightlyPhasePlanning.kt
+++ b/app/src/main/java/com/neubofy/reality/data/nightly/NightlyPhasePlanning.kt
@@ -198,7 +198,7 @@ class NightlyPhasePlanning(
         }
 
         listener.onStepStarted(NightlySteps.STEP_GENERATE_PLAN, "AI Parsing Plan")
-        saveStepState(NightlySteps.STEP_GENERATE_PLAN, StepProgress.STATUS_RUNNING, "Reading plan...")
+        saveStepState(NightlySteps.STEP_GENERATE_PLAN, StepProgress.STATUS_RUNNING, "Loading doc...")
 
         try {
             val nightlyModel = com.neubofy.reality.utils.SecurePreferences.get(context, "ai_prefs").getString("nightly_model", "@cf/openai/gpt-oss-120b") ?: "@cf/openai/gpt-oss-120b"
@@ -222,6 +222,8 @@ class NightlyPhasePlanning(
                 GoogleDocsManager.getDocumentContent(context, planId) ?: ""
             }
 
+            saveStepState(NightlySteps.STEP_GENERATE_PLAN, StepProgress.STATUS_RUNNING, "Got doc length ${planContent.length}")
+
             if (planContent.length < 20) {
                 val errorDetails = "Plan too short. Please write your tasks and schedule in the plan document."
                 saveStepState(NightlySteps.STEP_GENERATE_PLAN, StepProgress.STATUS_ERROR, errorDetails)
@@ -229,13 +231,15 @@ class NightlyPhasePlanning(
                 return
             }
 
-            saveStepState(NightlySteps.STEP_GENERATE_PLAN, StepProgress.STATUS_RUNNING, "AI parsing...")
+            saveStepState(NightlySteps.STEP_GENERATE_PLAN, StepProgress.STATUS_RUNNING, "Sending ${planContent.length} chars to AI...")
 
             // Fetch Task List Configs for AI context
             val taskListConfigs = withContext(Dispatchers.IO) {
                 AppDatabase.getDatabase(context).taskListConfigDao().getAll()
             }
             val aiResponse = NightlyAIHelper.analyzePlan(context, nightlyModel, planContent, taskListConfigs)
+
+            saveStepState(NightlySteps.STEP_GENERATE_PLAN, StepProgress.STATUS_RUNNING, "AI returned ${aiResponse.length} chars. Validating JSON...")
 
             // Validate JSON with robust extraction
             try {
@@ -298,7 +302,7 @@ class NightlyPhasePlanning(
                 listener.onStepCompleted(NightlySteps.STEP_GENERATE_PLAN, "Plan Parsed", details)
                 saveStepState(NightlySteps.STEP_GENERATE_PLAN, StepProgress.STATUS_COMPLETED, details, resultJson)
             } catch (e: Exception) {
-                val errorDetails = "AI response was not valid JSON. Please try again or simplify your plan."
+                val errorDetails = "AI parse error: ${e.message?.take(50)}. Response: ${aiResponse.take(50)}..."
                 TerminalLogger.log("Step 9 JSON parse error: ${e.message}, Raw: $aiResponse")
 
                 val failureJson = JSONObject().apply {
@@ -830,6 +834,8 @@ class NightlyPhasePlanning(
                 deferredTasks.awaitAll().forEach { allPendingTasks.addAll(it) }
             }
             
+            saveStepState(NightlySteps.STEP_NORMALIZE_TASKS, StepProgress.STATUS_RUNNING, "Found ${allPendingTasks.size} pending tasks")
+
             if (allPendingTasks.isEmpty()) {
                 saveStepState(NightlySteps.STEP_NORMALIZE_TASKS, StepProgress.STATUS_COMPLETED, "No tasks to clean")
                 listener.onStepCompleted(NightlySteps.STEP_NORMALIZE_TASKS, "Task Cleanup", "No pending tasks found")
@@ -839,7 +845,7 @@ class NightlyPhasePlanning(
             // 3. Prepare JSON for AI
             val tasksJsonStr = JSONArray(allPendingTasks).toString()
             
-            saveStepState(NightlySteps.STEP_NORMALIZE_TASKS, StepProgress.STATUS_RUNNING, "AI analyzing ${allPendingTasks.size} tasks...")
+            saveStepState(NightlySteps.STEP_NORMALIZE_TASKS, StepProgress.STATUS_RUNNING, "Sending ${allPendingTasks.size} tasks to AI...")
             
             // 4. Call AI (Using Standardized Model)
             val model = com.neubofy.reality.utils.SecurePreferences.get(context, "ai_prefs").getString("nightly_model", "@cf/openai/gpt-oss-120b") ?: "@cf/openai/gpt-oss-120b"
@@ -855,6 +861,8 @@ class NightlyPhasePlanning(
                 taskListConfigs = taskListConfigs
             )
             
+            saveStepState(NightlySteps.STEP_NORMALIZE_TASKS, StepProgress.STATUS_RUNNING, "AI returned ${aiResponse.length} chars. Validating JSON...")
+
             // 5. Parse AI Response
             val responseJson = try {
                 var jsonStr = if (aiResponse.contains("```json")) {
@@ -872,7 +880,11 @@ class NightlyPhasePlanning(
                 if (e.message?.contains("null output") == true) {
                     throw e
                 }
-                JSONObject(aiResponse) // Try direct parse
+                try {
+                    JSONObject(aiResponse) // Try direct parse
+                } catch (jsonException: Exception) {
+                    throw Exception("AI response was not valid JSON. Response: ${aiResponse.take(100)}...")
+                }
             }
             
             val deleteIds = responseJson.optJSONArray("delete_ids")

--- a/app/src/main/java/com/neubofy/reality/ui/activity/NightlyActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/NightlyActivity.kt
@@ -75,15 +75,7 @@ class NightlyActivity : BaseActivity(), NightlyProtocolExecutor.NightlyProgressL
         lifecycleScope.launch {
             NightlyRepository.observeSteps(this@NightlyActivity, selectedDate).collectLatest { steps ->
                 steps.forEach { step ->
-                    val hasData = !step.resultJson.isNullOrEmpty()
-                    val realStatus = if (hasData) {
-                        com.neubofy.reality.data.nightly.StepProgress.STATUS_COMPLETED
-                    } else if (step.status == com.neubofy.reality.data.nightly.StepProgress.STATUS_RUNNING) {
-                        // If it's running but we are just observing, keep it as running
-                        step.status
-                    } else {
-                        step.status
-                    }
+                    val realStatus = step.status
                     
                     val statusText = when (realStatus) {
                         com.neubofy.reality.data.nightly.StepProgress.STATUS_COMPLETED -> step.details ?: "Completed"
@@ -110,27 +102,26 @@ class NightlyActivity : BaseActivity(), NightlyProtocolExecutor.NightlyProgressL
     }
 
     private fun updateDependentSteps(stepStates: Map<Int, com.neubofy.reality.data.db.NightlyStep>) {
-        // Helper function: Step is "OK" if it has non-empty resultJson (consistent with observer)
+        // Helper function: Step is "OK" if its status is COMPLETED
         fun isStepOk(stepId: Int): Boolean {
             val step = stepStates[stepId] ?: return false
-            return !step.resultJson.isNullOrEmpty()
+            return step.status == com.neubofy.reality.data.nightly.StepProgress.STATUS_COMPLETED
         }
         
-        // Step 6 (Analyze Reflection) requires Step 5 (Create Diary) to have data
+        // Step 6 (Analyze Reflection) requires Step 5 (Create Diary) to be completed
         stepAdapter.setStepEnabled(NightlyProtocolExecutor.STEP_ANALYZE_REFLECTION, isStepOk(NightlyProtocolExecutor.STEP_CREATE_DIARY))
         
-        // Step 9 (Generate Plan) requires Step 8 (Create Plan Doc) to have data
+        // Step 9 (Generate Plan) requires Step 8 (Create Plan Doc) to be completed
         stepAdapter.setStepEnabled(NightlyProtocolExecutor.STEP_GENERATE_PLAN, isStepOk(NightlyProtocolExecutor.STEP_CREATE_PLAN_DOC))
         
-        // Step 10 (Process Plan) requires Step 9 (Generate Plan) to have data
+        // Step 10 (Process Plan) requires Step 9 (Generate Plan) to be completed
         stepAdapter.setStepEnabled(NightlyProtocolExecutor.STEP_PROCESS_PLAN, isStepOk(NightlyProtocolExecutor.STEP_GENERATE_PLAN))
         
-        // Step 14 (Normalize Tasks) requires Step 10 (Process Plan) to have data
+        // Step 14 (Normalize Tasks) requires Step 10 (Process Plan) to be completed
         stepAdapter.setStepEnabled(NightlyProtocolExecutor.STEP_NORMALIZE_TASKS, isStepOk(NightlyProtocolExecutor.STEP_PROCESS_PLAN))
         
-        // Step 12 (Generate PDF) requires Step 11 (Generate Report) - check status completed
-        val step11 = stepStates[NightlyProtocolExecutor.STEP_GENERATE_REPORT]
-        val step11Ok = step11 != null && (step11.status == com.neubofy.reality.data.nightly.StepProgress.STATUS_COMPLETED || !step11.resultJson.isNullOrEmpty())
+        // Step 12 (Generate PDF) requires Step 11 (Generate Report) to be completed
+        val step11Ok = isStepOk(NightlyProtocolExecutor.STEP_GENERATE_REPORT)
         stepAdapter.setStepEnabled(NightlyProtocolExecutor.STEP_GENERATE_PDF, step11Ok)
         
         // Log for debugging


### PR DESCRIPTION
This resolves the user's issue with the Nightly Protocol UI incorrectly showing failed steps as completed, and lack of visibility into long-running AI processes (Steps 9 and 14). Specifically, the patch decouples `resultJson` parsing from the UI status check, meaning error traces stored in JSON no longer cause false successes, and introduces step-by-step diagnostic text for both Step 9 and 14.

---
*PR created automatically by Jules for task [1261214495630431371](https://jules.google.com/task/1261214495630431371) started by @pawanwashudev-official*