### PR TITLE
Fix App Blocking Modes Evaluation Logic

### DIFF
--- a/app/src/main/java/com/neubofy/reality/Constants.kt
+++ b/app/src/main/java/com/neubofy/reality/Constants.kt
@@ -147,7 +147,7 @@ class Constants {
         var blockInFocus: Boolean = true,       // Custom Focus Mode
         var blockInAutoFocus: Boolean = true,   // Scheduled Auto Focus
         var blockInBedtime: Boolean = true,     // Bedtime Mode
-        var blockInCalendar: Boolean = true     // Calendar Events
+        var blockInTapasya: Boolean = true      // Tapasya Mode
     )
     
     // Settings Page Learning - Device-specific class names

--- a/app/src/main/java/com/neubofy/reality/ui/fragments/BlocklistAppsFragment.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/fragments/BlocklistAppsFragment.kt
@@ -173,7 +173,7 @@ class BlocklistAppsFragment : Fragment() {
         val cbFocus: CheckBox = v.findViewById(R.id.cbFocus)
         val cbAutoFocus: CheckBox = v.findViewById(R.id.cbAutoFocus)
         val cbBedtime: CheckBox = v.findViewById(R.id.cbBedtime)
-        val cbCalendar: CheckBox = v.findViewById(R.id.cbCalendar)
+        val cbTapasya: CheckBox = v.findViewById(R.id.cbTapasya)
     }
 
     inner class ApplicationAdapter(
@@ -221,12 +221,12 @@ class BlocklistAppsFragment : Fragment() {
             holder.cbFocus.setOnCheckedChangeListener(null)
             holder.cbAutoFocus.setOnCheckedChangeListener(null)
             holder.cbBedtime.setOnCheckedChangeListener(null)
-            holder.cbCalendar.setOnCheckedChangeListener(null)
+            holder.cbTapasya.setOnCheckedChangeListener(null)
             
             holder.cbFocus.isChecked = config.blockInFocus
             holder.cbAutoFocus.isChecked = config.blockInAutoFocus
             holder.cbBedtime.isChecked = config.blockInBedtime
-            holder.cbCalendar.isChecked = config.blockInCalendar
+            holder.cbTapasya.isChecked = config.blockInTapasya
             
             // Mode checkbox listeners - save immediately AND refresh service
             val modeChangeListener = object : android.widget.CompoundButton.OnCheckedChangeListener {
@@ -243,7 +243,7 @@ class BlocklistAppsFragment : Fragment() {
                             blockInFocus = holder.cbFocus.isChecked,
                             blockInAutoFocus = holder.cbAutoFocus.isChecked,
                             blockInBedtime = holder.cbBedtime.isChecked,
-                            blockInCalendar = holder.cbCalendar.isChecked
+                            blockInTapasya = holder.cbTapasya.isChecked
                         )
                         savedPreferencesLoader.updateBlockedAppConfig(updatedConfig)
                         onConfigChanged() // Trigger refresh
@@ -254,7 +254,7 @@ class BlocklistAppsFragment : Fragment() {
             holder.cbFocus.setOnCheckedChangeListener(modeChangeListener)
             holder.cbAutoFocus.setOnCheckedChangeListener(modeChangeListener)
             holder.cbBedtime.setOnCheckedChangeListener(modeChangeListener)
-            holder.cbCalendar.setOnCheckedChangeListener(modeChangeListener)
+            holder.cbTapasya.setOnCheckedChangeListener(modeChangeListener)
 
             // Expand button click
             holder.btnExpand.setOnClickListener {

--- a/app/src/main/java/com/neubofy/reality/ui/fragments/BlocklistWebsitesFragment.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/fragments/BlocklistWebsitesFragment.kt
@@ -123,7 +123,7 @@ class BlocklistWebsitesFragment : Fragment() {
             val cbFocus: android.widget.CheckBox = itemView.findViewById(com.neubofy.reality.R.id.cbFocus)
             val cbAutoFocus: android.widget.CheckBox = itemView.findViewById(com.neubofy.reality.R.id.cbAutoFocus)
             val cbBedtime: android.widget.CheckBox = itemView.findViewById(com.neubofy.reality.R.id.cbBedtime)
-            val cbCalendar: android.widget.CheckBox = itemView.findViewById(com.neubofy.reality.R.id.cbCalendar)
+            val cbTapasya: android.widget.CheckBox = itemView.findViewById(com.neubofy.reality.R.id.cbTapasya)
         }
         
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
@@ -144,12 +144,12 @@ class BlocklistWebsitesFragment : Fragment() {
             holder.cbFocus.setOnCheckedChangeListener(null)
             holder.cbAutoFocus.setOnCheckedChangeListener(null)
             holder.cbBedtime.setOnCheckedChangeListener(null)
-            holder.cbCalendar.setOnCheckedChangeListener(null)
+            holder.cbTapasya.setOnCheckedChangeListener(null)
             
             holder.cbFocus.isChecked = config.blockInFocus
             holder.cbAutoFocus.isChecked = config.blockInAutoFocus
             holder.cbBedtime.isChecked = config.blockInBedtime
-            holder.cbCalendar.isChecked = config.blockInCalendar
+            holder.cbTapasya.isChecked = config.blockInTapasya
             
             // Mode checkbox listeners
             val modeChangeListener = { _: android.widget.CompoundButton, _: Boolean ->
@@ -158,7 +158,7 @@ class BlocklistWebsitesFragment : Fragment() {
                     blockInFocus = holder.cbFocus.isChecked,
                     blockInAutoFocus = holder.cbAutoFocus.isChecked,
                     blockInBedtime = holder.cbBedtime.isChecked,
-                    blockInCalendar = holder.cbCalendar.isChecked
+                    blockInTapasya = holder.cbTapasya.isChecked
                 )
                 prefs.updateBlockedAppConfig(updatedConfig)
                 onConfigChanged()
@@ -166,7 +166,7 @@ class BlocklistWebsitesFragment : Fragment() {
             holder.cbFocus.setOnCheckedChangeListener(modeChangeListener)
             holder.cbAutoFocus.setOnCheckedChangeListener(modeChangeListener)
             holder.cbBedtime.setOnCheckedChangeListener(modeChangeListener)
-            holder.cbCalendar.setOnCheckedChangeListener(modeChangeListener)
+            holder.cbTapasya.setOnCheckedChangeListener(modeChangeListener)
             
             // Expand button
             holder.btnExpand.setOnClickListener {

--- a/app/src/main/java/com/neubofy/reality/utils/BlockCache.kt
+++ b/app/src/main/java/com/neubofy/reality/utils/BlockCache.kt
@@ -189,7 +189,9 @@ object BlockCache {
                 val schedules = prefs.loadAutoFocusHoursList()
                 val calendarEvents = db.calendarEventDao().getCurrentEvents(now)
                 
-                val isFocusActive = focusData.isTurnedOn && focusData.endTime > now
+                val isFocusActiveRaw = focusData.isTurnedOn && focusData.endTime > now
+                val isTapasyaActive = isFocusActiveRaw && focusData.isTapasyaTriggered
+                val isManualFocusActive = isFocusActiveRaw && !focusData.isTapasyaTriggered
                 
                 // AUTO-CLEANUP: If Focus Mode expired, reset the flag
                 if (focusData.isTurnedOn && focusData.endTime <= now) {
@@ -202,7 +204,7 @@ object BlockCache {
                 val isScheduleActive = isAnyScheduleActive(schedules, currentMins, currentDay)
                 val isCalendarEventActive = calendarEvents.isNotEmpty()
                 
-                isAnyBlockingModeActive = isFocusActive || isBedtimeActive || 
+                isAnyBlockingModeActive = isFocusActiveRaw || isBedtimeActive ||
                                           isScheduleActive || isCalendarEventActive
                 isBedtimeCurrentlyActive = isBedtimeActive
                 
@@ -220,40 +222,24 @@ object BlockCache {
                     val appConfigs = prefs.loadBlockedAppConfigs()
                     val configMap = appConfigs.associateBy { it.packageName }
                     
-                    // Determine active mode for filtering
-                    val activeMode = when {
-                        isFocusActive -> "FOCUS"
-                        isBedtimeActive -> "BEDTIME"
-                        isScheduleActive -> "AUTO_FOCUS"
-                        isCalendarEventActive -> "CALENDAR"
-                        else -> "NONE"
-                    }
-                    
-                    // Determine reason
-                    val reason = when (activeMode) {
-                        "FOCUS" -> "Focus Mode"
-                        "BEDTIME" -> "Bedtime Mode"
-                        "AUTO_FOCUS" -> "Scheduled Block"
-                        "CALENDAR" -> "Calendar Event"
-                        else -> "Blocked"
-                    }
-                    
                     if (modeType == com.neubofy.reality.Constants.FOCUS_MODE_BLOCK_SELECTED) {
                         // Block selected apps (with per-app mode filtering)
                         blocklist.forEach { pkg ->
                             if (pkg.isNotEmpty()) {
-                                // Check if this app should be blocked for the current mode
                                 val config = configMap[pkg] ?: com.neubofy.reality.Constants.BlockedAppConfig(pkg)
-                                val shouldBlock = when (activeMode) {
-                                    "FOCUS" -> config.blockInFocus
-                                    "BEDTIME" -> config.blockInBedtime
-                                    "AUTO_FOCUS" -> config.blockInAutoFocus
-                                    "CALENDAR" -> config.blockInCalendar
-                                    else -> true
-                                }
                                 
-                                if (shouldBlock) {
-                                    addToBox(newBox, pkg, reason)
+                                // Check all active modes independently
+                                if (isTapasyaActive && config.blockInTapasya) {
+                                    addToBox(newBox, pkg, "Tapasya Mode")
+                                }
+                                if (isManualFocusActive && config.blockInFocus) {
+                                    addToBox(newBox, pkg, "Focus Mode")
+                                }
+                                if (isBedtimeActive && config.blockInBedtime) {
+                                    addToBox(newBox, pkg, "Bedtime Mode")
+                                }
+                                if ((isScheduleActive || isCalendarEventActive) && config.blockInAutoFocus) {
+                                    addToBox(newBox, pkg, "Scheduled Block")
                                 }
                             }
                         }

--- a/app/src/main/res/layout/item_blocklist_app_expandable.xml
+++ b/app/src/main/res/layout/item_blocklist_app_expandable.xml
@@ -96,10 +96,10 @@
             android:checked="true" />
 
         <CheckBox
-            android:id="@+id/cbCalendar"
+            android:id="@+id/cbTapasya"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Calendar Events"
+            android:text="Tapasya"
             android:textSize="14sp"
             android:checked="true" />
 

--- a/app/src/main/res/layout/item_website_expandable.xml
+++ b/app/src/main/res/layout/item_website_expandable.xml
@@ -98,10 +98,10 @@
             android:checked="true" />
 
         <CheckBox
-            android:id="@+id/cbCalendar"
+            android:id="@+id/cbTapasya"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Calendar Events"
+            android:text="Tapasya"
             android:textSize="14sp"
             android:checked="true" />
 


### PR DESCRIPTION
Refactored the application's blocking logic to give users independent control over blocking for each of the four features: Tapasya Mode, Bedtime Mode, Auto Focus (combining Custom Schedules and Calendar Events), and Manual Focus Mode. Previously, Tapasya and Manual Focus modes shared the same configuration flag, and the blocking cache evaluated modes strictly top-down, resulting in cases where Tapasya would block an app, but normal Manual focus would fail to block it correctly if user configuration conflicted. The refactoring addresses this by introducing `blockInTapasya` and concurrently evaluating all active blocking modes to decide if an app should be restricted. UI layouts and logic fragments have been fully updated to support this separation.

---
*PR created automatically by Jules for task [13829898269235282055](https://jules.google.com/task/13829898269235282055) started by @pawanwashudev-official*