### PR TITLE
Fix Time Drift Bug and Improve Bedtime TimePicker UI

### DIFF
--- a/app/src/main/java/com/neubofy/reality/ui/activity/BedtimeActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/BedtimeActivity.kt
@@ -50,6 +50,10 @@ class BedtimeActivity : BaseActivity() {
             bedtimeData.isEnabled = isChecked
             prefsLoader.saveBedtimeData(bedtimeData)
             updateUI()
+
+            val intent = Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE)
+            intent.setPackage(packageName)
+            sendBroadcast(intent)
         }
         
         binding.btnStartTime.setOnClickListener {
@@ -151,6 +155,10 @@ class BedtimeActivity : BaseActivity() {
             }
             prefsLoader.saveBedtimeData(bedtimeData)
             updateUI()
+
+            val intent = Intent(com.neubofy.reality.services.AppBlockerService.INTENT_ACTION_REFRESH_FOCUS_MODE)
+            intent.setPackage(packageName)
+            sendBroadcast(intent)
         }
         
         picker.show(supportFragmentManager, "TIME_PICKER")

--- a/app/src/main/java/com/neubofy/reality/ui/activity/BedtimeActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/BedtimeActivity.kt
@@ -136,7 +136,7 @@ class BedtimeActivity : BaseActivity() {
         val min = currentMins % 60
         
         val picker = MaterialTimePicker.Builder()
-            .setTimeFormat(TimeFormat.CLOCK_24H)
+            .setTimeFormat(TimeFormat.CLOCK_12H)
             .setHour(hour)
             .setMinute(min)
             .setTitleText(if (isStartTime) "Select start time" else "Select end time")

--- a/app/src/main/java/com/neubofy/reality/ui/activity/NightlySettingsActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/NightlySettingsActivity.kt
@@ -309,7 +309,7 @@ class NightlySettingsActivity : BaseActivity() {
         val minute = currentMinutes % 60
         
         com.google.android.material.timepicker.MaterialTimePicker.Builder()
-            .setTimeFormat(com.google.android.material.timepicker.TimeFormat.CLOCK_24H)
+            .setTimeFormat(com.google.android.material.timepicker.TimeFormat.CLOCK_12H)
             .setHour(hour)
             .setMinute(minute)
             .setTitleText(if (isStartTime) "Select Start Time" else "Select End Time")

--- a/app/src/main/java/com/neubofy/reality/ui/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/SettingsActivity.kt
@@ -479,10 +479,10 @@ class SettingsActivity : BaseActivity() {
                 binding.tvRealitySleepStatus.setTextColor(ContextCompat.getColor(this, android.R.color.holo_red_light))
                 if (isRealitySleepEnabled) prefs.saveRealitySleepEnabled(false)
             } else if (isRealitySleepEnabled) {
-                binding.tvRealitySleepStatus.text = "Enabled (Grayscale, Dim & Dark)"
+                binding.tvRealitySleepStatus.text = "Enabled (Grayscale, Dim & Dark on Bedtime)"
                 binding.tvRealitySleepStatus.setTextColor(ContextCompat.getColor(this, android.R.color.holo_green_light))
             } else {
-                binding.tvRealitySleepStatus.text = "Grayscale, Dim & Dark Mode"
+                binding.tvRealitySleepStatus.text = "Grayscale, Dim & Dark Mode on Schedule"
                 binding.tvRealitySleepStatus.setTextColor(ContextCompat.getColor(this, android.R.color.darker_gray))
             }
         } else {

--- a/app/src/main/java/com/neubofy/reality/ui/activity/SmartSleepActivity.kt
+++ b/app/src/main/java/com/neubofy/reality/ui/activity/SmartSleepActivity.kt
@@ -514,7 +514,7 @@ class SmartSleepActivity : BaseActivity() {
         val zdt = instant.atZone(ZoneId.systemDefault())
         
         val picker = MaterialTimePicker.Builder()
-            .setTimeFormat(TimeFormat.CLOCK_24H)
+            .setTimeFormat(TimeFormat.CLOCK_12H)
             .setHour(zdt.hour)
             .setMinute(zdt.minute)
             .setTitleText(if (isStart) "Slept at" else "Woke up at")
@@ -534,7 +534,7 @@ class SmartSleepActivity : BaseActivity() {
 
     private fun showAddSleepPicker() {
         val picker = MaterialTimePicker.Builder()
-            .setTimeFormat(TimeFormat.CLOCK_24H)
+            .setTimeFormat(TimeFormat.CLOCK_12H)
             .setTitleText("New Sleep Start")
             .setHour(23).setMinute(0).build()
             
@@ -546,7 +546,7 @@ class SmartSleepActivity : BaseActivity() {
 
     private fun showAddWakePicker(sh: Int, sm: Int) {
         val picker = MaterialTimePicker.Builder()
-            .setTimeFormat(TimeFormat.CLOCK_24H)
+            .setTimeFormat(TimeFormat.CLOCK_12H)
             .setTitleText("New Wake Time")
             .setHour(7).setMinute(0).build()
             

--- a/app/src/main/java/com/neubofy/reality/utils/SecureTimeProvider.kt
+++ b/app/src/main/java/com/neubofy/reality/utils/SecureTimeProvider.kt
@@ -55,13 +55,24 @@ object SecureTimeProvider {
         // If elapsedRealtime has reset (reboot) or is lower than last known elapsed,
         // we recalculate the offset using the last recorded time as the minimum baseline time.
         if (elapsedRealtime < lastKnownElapsed) {
-            val newOffset = lastRecordedTime - elapsedRealtime
-            cachedOffset = newOffset
-            prefs.edit()
-                .putLong(KEY_TIME_OFFSET, newOffset)
-                .putLong(KEY_LAST_KNOWN_ELAPSED, elapsedRealtime)
-                .apply()
-            calculatedTime = lastRecordedTime
+            val currentSystemTime = System.currentTimeMillis()
+            if (currentSystemTime > lastRecordedTime) {
+                val newOffset = currentSystemTime - elapsedRealtime
+                cachedOffset = newOffset
+                prefs.edit()
+                    .putLong(KEY_TIME_OFFSET, newOffset)
+                    .putLong(KEY_LAST_KNOWN_ELAPSED, elapsedRealtime)
+                    .apply()
+                calculatedTime = currentSystemTime
+            } else {
+                val newOffset = lastRecordedTime - elapsedRealtime
+                cachedOffset = newOffset
+                prefs.edit()
+                    .putLong(KEY_TIME_OFFSET, newOffset)
+                    .putLong(KEY_LAST_KNOWN_ELAPSED, elapsedRealtime)
+                    .apply()
+                calculatedTime = lastRecordedTime
+            }
         } else {
             // Check if user set system clock backward below last recorded time
             if (calculatedTime < lastRecordedTime) {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -736,7 +736,7 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Reality Sleep Mode"
+                            android:text="Auto Dark Mode &amp; Grayscale on Bedtime (Android 15+)"
                             android:textColor="?attr/colorPrimary"
                                 android:fontFamily="monospace"
                             android:textSize="16sp"
@@ -747,7 +747,7 @@
                             android:id="@+id/tv_reality_sleep_status"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Grayscale, Dim &amp; Dark Mode"
+                            android:text="Grayscale, Dim &amp; Dark Mode on Schedule"
                             android:textColor="?attr/colorOnSurfaceVariant"
                             android:textSize="12sp" />
                     </LinearLayout>


### PR DESCRIPTION
Fixes the bug where bedtime features triggered outside of the scheduled bedtime due to `SecureTimeProvider` time freezing across device reboots. This is resolved by accepting `System.currentTimeMillis()` if it moves forward past the last recorded time upon reboot. The update also clarifies the UI labels for Reality Sleep mode to indicate it triggers on schedule, and changes the time picker default to the 12-hour clock layout.

---
*PR created automatically by Jules for task [7937046939601365776](https://jules.google.com/task/7937046939601365776) started by @pawanwashudev-official*