### PR TITLE
Fix App Blocker reliability and warning cancellation

### DIFF
--- a/app/src/main/java/com/neubofy/reality/services/AppBlockerService.kt
+++ b/app/src/main/java/com/neubofy/reality/services/AppBlockerService.kt
@@ -125,6 +125,12 @@ class AppBlockerService : BaseBlockingService() {
                     isScreenOn = false
                     browserWatchdog.stopBrowserCheckTimer() // Save battery when screen off
                 }
+                Intent.ACTION_SCREEN_ON -> {
+                    isScreenOn = true
+                    if (isBlockingActive) {
+                        checkCurrentWindow()
+                    }
+                }
                 Intent.ACTION_USER_PRESENT -> {
                     isScreenOn = true
                     
@@ -350,7 +356,7 @@ class AppBlockerService : BaseBlockingService() {
             }
 
         } else {
-            if (currentWarnedPackage == packageName) {
+            if (currentWarnedPackage != null && packageName != "com.android.systemui") {
                 cancelWarning()
             }
         }
@@ -592,7 +598,7 @@ class AppBlockerService : BaseBlockingService() {
             addAction(INTENT_ACTION_STOP_LEARNING)
             addAction(INTENT_ACTION_START_CUSTOM_PAGE_LEARNING)
             addAction(Intent.ACTION_SCREEN_OFF)
-
+            addAction(Intent.ACTION_SCREEN_ON)
             addAction(Intent.ACTION_USER_PRESENT)
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {


### PR DESCRIPTION
Fixed an issue where the app blocker would stop tracking activity after the first block by implementing `ACTION_SCREEN_ON` tracking to better handle devices that don't emit `ACTION_USER_PRESENT`. Also fixed the cancel warning logic to prevent the block screen from firing if the user already backed out of a blocked app before the timer finishes.

---
*PR created automatically by Jules for task [1219730754220983028](https://jules.google.com/task/1219730754220983028) started by @pawanwashudev-official*